### PR TITLE
Fix image loading/rendering bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,6 @@ function drawCard(context, p, word) {
     context.fillText(word, p.x + mwidth, p.y + mheight); 
 }
 function drawImage(context, p, src) {
-    console.log(src);
     var img = new Image();
     img.src = 'images/' + src;
     img.onload = function() {

--- a/main.js
+++ b/main.js
@@ -16,9 +16,12 @@ function drawCard(context, p, word) {
     context.fillText(word, p.x + mwidth, p.y + mheight); 
 }
 function drawImage(context, p, src) {
-    img = new Image();
+    console.log(src);
+    var img = new Image();
     img.src = 'images/' + src;
-    context.drawImage(img, 0, 0, 222, 310, p.x, p.y, cwidth, cheight);    
+    img.onload = function() {
+        context.drawImage(img, 0, 0, 222, 310, p.x, p.y, cwidth, cheight);    
+    }
 }
 
 function to2d(n) {


### PR DESCRIPTION
The img object was being dumped into globals, and there wasn't an onload for it so they were trying to draw before loading.
